### PR TITLE
Fix model path and Docker entry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app
 
 # Roda o script que treina o modelo (gera modelo_rf.pkl e input_columns.pkl)
-RUN python train_model.py
+RUN python model/train_model.py
 
 # Expõe a porta usada pela API Flask
 EXPOSE 5000
 
 # Comando padrão ao iniciar o container
-CMD ["python", "app.py"]
+CMD ["python", "app/main.py"]

--- a/app/main.py
+++ b/app/main.py
@@ -2,10 +2,14 @@
 from flask import Flask, request, jsonify
 import joblib
 import pandas as pd
+from pathlib import Path
+
+# Caminho base do projeto (dois niveis acima deste arquivo)
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Carrega o modelo e as colunas usadas no treino
-model = joblib.load("modelo_rf.pkl")
-input_columns = joblib.load("input_columns.pkl")
+model = joblib.load(BASE_DIR / "model" / "modelo_rf.pkl")
+input_columns = joblib.load(BASE_DIR / "model" / "input_columns.pkl")
 
 app = Flask(__name__)
 


### PR DESCRIPTION
## Summary
- use project root when loading model files
- run train script and API entry from correct paths

## Testing
- `python -m py_compile app/main.py model/train_model.py app/model_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685d8f29e6fc832f93d727cdf2084230